### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">= 7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.3.0"
+        "phpunit/phpunit": "~7.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
php composer.phar install
を実行すると、

> Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it.
> No replacement was suggested.

というメッセージが表示されたので、
https://stackoverflow.com/questions/55696556/how-to-fix-this-error-package-phpunit-phpunit-mock-objects-is-abandoned-you-sho/56568823
ここを参考に手直ししてみました。