### PR TITLE
Fix make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ composer-outdated:
 	$(CMD) -v $(VOLUME) -w $(WORKDIR) composer:1 outdated
 
 test:
-	$(CMD) -v $(VOLUME) -w $(WORKDIR) $(PHP) ./vendor/bin/phpunit
+	$(CMD) -v $(VOLUME) -w $(WORKDIR) $(PHP) ./vendor/bin/phpunit --testdox
 
 clean:
 	rm -rf ./vendor

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ $
 
 のようにテストが正常終了すればOKです。
 
+testdox アノテーションについて
+----------------------------
+
+`make test`でのテスト実行時に TestDox 形式で結果が出力されるようになっています。
+
+クラスやメソッドの PHPDoc に`@testdox XXX`と記述することでテスト結果の出力を任意の文字列にすることができます。
+
+記述方法については [ExampleTest.php](https://github.com/tddbc/php_phpunit/blob/master/tests/Tddbc/ExampleTest.php) を参照してください。
+
 ライセンス
 ---------
 

--- a/tests/Tddbc/ExampleTest.php
+++ b/tests/Tddbc/ExampleTest.php
@@ -4,6 +4,9 @@ namespace Tddbc;
 use PHPUnit\Framework\TestCase;
 use Tddbc\Example;
 
+/**
+ * @testdox サンプルテスト
+ */
 class ExampleTest extends TestCase
 {
     /**
@@ -21,6 +24,7 @@ class ExampleTest extends TestCase
 
     /**
      * @test
+     * @testdox 文字列 'TDDBC' を渡すと文字列 'hello TDDBC' を返す
      */
     public function say()
     {


### PR DESCRIPTION
## 変更内容

- `make test`に`--testdox`オプションを追加しました。
  - 実行しているテストの内容が明示的になるため。
- `ExampleTest.php`に`@testdox`を追加しました。
- README に `testdox アノテーションについて`という項目を追記しました。